### PR TITLE
ANDROID: Faster landmarks read back

### DIFF
--- a/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
+++ b/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
@@ -68,10 +68,10 @@ public partial class FaceLandmarkerResult
     private static class RawFaceLandmarkJni
     {
         internal static readonly IntPtr FaceLandmarksMethod = JNIEnv.GetMethodID(class_ref, "faceLandmarks", "()Ljava/util/List;");
-        internal static readonly IntPtr JavaListClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/List"));
-        internal static readonly IntPtr JavaOptionalClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/Optional"));
-        internal static readonly IntPtr JavaFloatClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/lang/Float"));
-        internal static readonly IntPtr NormalizedLandmarkClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("com/google/mediapipe/tasks/components/containers/NormalizedLandmark"));
+        private static readonly IntPtr JavaListClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/List"));
+        private static readonly IntPtr JavaOptionalClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/Optional"));
+        private static readonly IntPtr JavaFloatClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/lang/Float"));
+        private static readonly IntPtr NormalizedLandmarkClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("com/google/mediapipe/tasks/components/containers/NormalizedLandmark"));
         internal static readonly IntPtr ListSizeMethod = JNIEnv.GetMethodID(JavaListClass, "size", "()I");
         internal static readonly IntPtr ListGetMethod = JNIEnv.GetMethodID(JavaListClass, "get", "(I)Ljava/lang/Object;");
         internal static readonly IntPtr OptionalIsPresentMethod = JNIEnv.GetMethodID(JavaOptionalClass, "isPresent", "()Z");
@@ -94,11 +94,10 @@ public partial class FaceLandmarkerResult
     /// <remarks>
     /// This method exists to avoid the heavy wrapper and JNI cost of traversing the
     /// generated <c>IList&lt;IList&lt;NormalizedLandmark&gt;&gt;</c> result shape in real-time paths.
-    /// The method is marked <c>unsafe</c> only because the implementation uses a stack-allocated
-    /// <c>JValue</c> scratch buffer to avoid per-call argument array allocations in the hot path.
-    /// The packed return shape itself does not inherently require unsafe code.
+    /// The underlying implementation uses a stack-allocated <c>JValue</c> scratch buffer
+    /// to avoid per-call argument array allocations in the hot path.
     /// </remarks>
-    public unsafe float[][] FaceLandmarksXY()
+    public float[][] FaceLandmarksXY()
     {
         return ExtractPackedCoordinates(includeZ: false);
     }
@@ -114,7 +113,7 @@ public partial class FaceLandmarkerResult
     /// This provides the same low-overhead traversal pattern as <see cref="FaceLandmarksXY"/>,
     /// but retains depth values for consumers that need the full coordinate triplet.
     /// </remarks>
-    public unsafe float[][] FaceLandmarksXYZ()
+    public float[][] FaceLandmarksXYZ()
     {
         return ExtractPackedCoordinates(includeZ: true);
     }

--- a/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
+++ b/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
@@ -67,24 +67,11 @@ public partial class FaceLandmarkerResult
 {
     private static class RawFaceLandmarkJni
     {
-        private static IntPtr NewGlobalClassRef(string className)
-        {
-            var localRef = JNIEnv.FindClass(className);
-            try
-            {
-                return JNIEnv.NewGlobalRef(localRef);
-            }
-            finally
-            {
-                JNIEnv.DeleteLocalRef(localRef);
-            }
-        }
-
         internal static readonly IntPtr FaceLandmarksMethod = JNIEnv.GetMethodID(class_ref, "faceLandmarks", "()Ljava/util/List;");
-        private static readonly IntPtr JavaListClass = NewGlobalClassRef("java/util/List");
-        private static readonly IntPtr JavaOptionalClass = NewGlobalClassRef("java/util/Optional");
-        private static readonly IntPtr JavaFloatClass = NewGlobalClassRef("java/lang/Float");
-        private static readonly IntPtr NormalizedLandmarkClass = NewGlobalClassRef("com/google/mediapipe/tasks/components/containers/NormalizedLandmark");
+        private static readonly IntPtr JavaListClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/List"));
+        private static readonly IntPtr JavaOptionalClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/Optional"));
+        private static readonly IntPtr JavaFloatClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/lang/Float"));
+        private static readonly IntPtr NormalizedLandmarkClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("com/google/mediapipe/tasks/components/containers/NormalizedLandmark"));
         internal static readonly IntPtr ListSizeMethod = JNIEnv.GetMethodID(JavaListClass, "size", "()I");
         internal static readonly IntPtr ListGetMethod = JNIEnv.GetMethodID(JavaListClass, "get", "(I)Ljava/lang/Object;");
         internal static readonly IntPtr OptionalIsPresentMethod = JNIEnv.GetMethodID(JavaOptionalClass, "isPresent", "()Z");

--- a/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
+++ b/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
@@ -67,11 +67,24 @@ public partial class FaceLandmarkerResult
 {
     private static class RawFaceLandmarkJni
     {
+        private static IntPtr NewGlobalClassRef(string className)
+        {
+            var localRef = JNIEnv.FindClass(className);
+            try
+            {
+                return JNIEnv.NewGlobalRef(localRef);
+            }
+            finally
+            {
+                JNIEnv.DeleteLocalRef(localRef);
+            }
+        }
+
         internal static readonly IntPtr FaceLandmarksMethod = JNIEnv.GetMethodID(class_ref, "faceLandmarks", "()Ljava/util/List;");
-        private static readonly IntPtr JavaListClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/List"));
-        private static readonly IntPtr JavaOptionalClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/Optional"));
-        private static readonly IntPtr JavaFloatClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/lang/Float"));
-        private static readonly IntPtr NormalizedLandmarkClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("com/google/mediapipe/tasks/components/containers/NormalizedLandmark"));
+        private static readonly IntPtr JavaListClass = NewGlobalClassRef("java/util/List");
+        private static readonly IntPtr JavaOptionalClass = NewGlobalClassRef("java/util/Optional");
+        private static readonly IntPtr JavaFloatClass = NewGlobalClassRef("java/lang/Float");
+        private static readonly IntPtr NormalizedLandmarkClass = NewGlobalClassRef("com/google/mediapipe/tasks/components/containers/NormalizedLandmark");
         internal static readonly IntPtr ListSizeMethod = JNIEnv.GetMethodID(JavaListClass, "size", "()I");
         internal static readonly IntPtr ListGetMethod = JNIEnv.GetMethodID(JavaListClass, "get", "(I)Ljava/lang/Object;");
         internal static readonly IntPtr OptionalIsPresentMethod = JNIEnv.GetMethodID(JavaOptionalClass, "isPresent", "()Z");

--- a/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
+++ b/MediaPipeTasksVision/Additions/FaceLandmarkerResult.cs
@@ -1,0 +1,320 @@
+using Android.Runtime;
+using Java.Interop;
+
+namespace MediaPipe.Tasks.Vision.FaceLandmarker;
+
+/// <summary>
+/// Holds packed landmark data for one detected face while avoiding the wrapper-heavy
+/// <c>NormalizedLandmark</c> object graph.
+/// </summary>
+public sealed class DetailedFaceLandmarks
+{
+    /// <summary>
+    /// Initializes a new packed landmark payload for one face.
+    /// </summary>
+    /// <param name="xyzCoordinates">Packed coordinates in <c>x0, y0, z0, x1, y1, z1, ...</c> order.</param>
+    /// <param name="visibility">Visibility values aligned to landmark index.</param>
+    /// <param name="hasVisibility">Flags that indicate whether each visibility entry is present.</param>
+    /// <param name="presence">Presence values aligned to landmark index.</param>
+    /// <param name="hasPresence">Flags that indicate whether each presence entry is present.</param>
+    public DetailedFaceLandmarks(float[] xyzCoordinates, float[] visibility, bool[] hasVisibility, float[] presence, bool[] hasPresence)
+    {
+        XYZCoordinates = xyzCoordinates;
+        Visibility = visibility;
+        HasVisibility = hasVisibility;
+        Presence = presence;
+        HasPresence = hasPresence;
+    }
+
+    /// <summary>
+    /// Gets packed coordinates in <c>x, y, z</c> triplets.
+    /// </summary>
+    public float[] XYZCoordinates { get; }
+
+    /// <summary>
+    /// Gets visibility values aligned to landmark index.
+    /// Entries whose corresponding <see cref="HasVisibility"/> value is <see langword="false"/> are unspecified.
+    /// </summary>
+    public float[] Visibility { get; }
+
+    /// <summary>
+    /// Gets flags that indicate whether each visibility value is present.
+    /// </summary>
+    public bool[] HasVisibility { get; }
+
+    /// <summary>
+    /// Gets presence values aligned to landmark index.
+    /// Entries whose corresponding <see cref="HasPresence"/> value is <see langword="false"/> are unspecified.
+    /// </summary>
+    public float[] Presence { get; }
+
+    /// <summary>
+    /// Gets flags that indicate whether each presence value is present.
+    /// </summary>
+    public bool[] HasPresence { get; }
+
+    /// <summary>
+    /// Gets the number of landmarks stored for this face.
+    /// </summary>
+    public int LandmarkCount => XYZCoordinates.Length / 3;
+}
+
+/// <summary>
+/// Provides Android-specific helper APIs for extracting face landmark data with minimal
+/// managed interop overhead.
+/// </summary>
+public partial class FaceLandmarkerResult
+{
+    private static class RawFaceLandmarkJni
+    {
+        internal static readonly IntPtr FaceLandmarksMethod = JNIEnv.GetMethodID(class_ref, "faceLandmarks", "()Ljava/util/List;");
+        internal static readonly IntPtr JavaListClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/List"));
+        internal static readonly IntPtr JavaOptionalClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/util/Optional"));
+        internal static readonly IntPtr JavaFloatClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("java/lang/Float"));
+        internal static readonly IntPtr NormalizedLandmarkClass = JNIEnv.NewGlobalRef(JNIEnv.FindClass("com/google/mediapipe/tasks/components/containers/NormalizedLandmark"));
+        internal static readonly IntPtr ListSizeMethod = JNIEnv.GetMethodID(JavaListClass, "size", "()I");
+        internal static readonly IntPtr ListGetMethod = JNIEnv.GetMethodID(JavaListClass, "get", "(I)Ljava/lang/Object;");
+        internal static readonly IntPtr OptionalIsPresentMethod = JNIEnv.GetMethodID(JavaOptionalClass, "isPresent", "()Z");
+        internal static readonly IntPtr OptionalGetMethod = JNIEnv.GetMethodID(JavaOptionalClass, "get", "()Ljava/lang/Object;");
+        internal static readonly IntPtr FloatValueMethod = JNIEnv.GetMethodID(JavaFloatClass, "floatValue", "()F");
+        internal static readonly IntPtr LandmarkXMethod = JNIEnv.GetMethodID(NormalizedLandmarkClass, "x", "()F");
+        internal static readonly IntPtr LandmarkYMethod = JNIEnv.GetMethodID(NormalizedLandmarkClass, "y", "()F");
+        internal static readonly IntPtr LandmarkZMethod = JNIEnv.GetMethodID(NormalizedLandmarkClass, "z", "()F");
+        internal static readonly IntPtr LandmarkVisibilityMethod = JNIEnv.GetMethodID(NormalizedLandmarkClass, "visibility", "()Ljava/util/Optional;");
+        internal static readonly IntPtr LandmarkPresenceMethod = JNIEnv.GetMethodID(NormalizedLandmarkClass, "presence", "()Ljava/util/Optional;");
+    }
+
+    /// <summary>
+    /// Extracts detected face landmarks into packed interleaved <c>x, y</c> coordinate arrays for fast access.
+    /// </summary>
+    /// <returns>
+    /// One array per detected face. Each inner array is laid out as
+    /// <c>x0, y0, x1, y1, ...</c> for that face's landmark sequence.
+    /// </returns>
+    /// <remarks>
+    /// This method exists to avoid the heavy wrapper and JNI cost of traversing the
+    /// generated <c>IList&lt;IList&lt;NormalizedLandmark&gt;&gt;</c> result shape in real-time paths.
+    /// The method is marked <c>unsafe</c> only because the implementation uses a stack-allocated
+    /// <c>JValue</c> scratch buffer to avoid per-call argument array allocations in the hot path.
+    /// The packed return shape itself does not inherently require unsafe code.
+    /// </remarks>
+    public unsafe float[][] FaceLandmarksXY()
+    {
+        return ExtractPackedCoordinates(includeZ: false);
+    }
+
+    /// <summary>
+    /// Extracts detected face landmarks into packed interleaved <c>x, y, z</c> coordinate arrays for fast access.
+    /// </summary>
+    /// <returns>
+    /// One array per detected face. Each inner array is laid out as
+    /// <c>x0, y0, z0, x1, y1, z1, ...</c> for that face's landmark sequence.
+    /// </returns>
+    /// <remarks>
+    /// This provides the same low-overhead traversal pattern as <see cref="FaceLandmarksXY"/>,
+    /// but retains depth values for consumers that need the full coordinate triplet.
+    /// </remarks>
+    public unsafe float[][] FaceLandmarksXYZ()
+    {
+        return ExtractPackedCoordinates(includeZ: true);
+    }
+
+    /// <summary>
+    /// Extracts detected face landmarks into packed coordinates plus optional visibility and presence values.
+    /// </summary>
+    /// <returns>
+    /// One packed face payload per detected face. Each payload contains <c>x, y, z</c> coordinates for every landmark,
+    /// along with aligned presence and visibility arrays plus per-entry presence flags.
+    /// </returns>
+    /// <remarks>
+    /// This method is intended for performance-sensitive consumers that need more metadata than
+    /// <see cref="FaceLandmarksXY"/> or <see cref="FaceLandmarksXYZ"/>, but still want to avoid
+    /// materializing the generated nested landmark wrapper graph.
+    /// </remarks>
+    public unsafe DetailedFaceLandmarks[] FaceLandmarksDetailed()
+    {
+        var outerListHandle = JNIEnv.CallObjectMethod(Handle, RawFaceLandmarkJni.FaceLandmarksMethod);
+        if (outerListHandle == IntPtr.Zero)
+            return [];
+
+        try
+        {
+            int faceCount = JNIEnv.CallIntMethod(outerListHandle, RawFaceLandmarkJni.ListSizeMethod);
+            if (faceCount <= 0)
+                return [];
+
+            var faces = new DetailedFaceLandmarks[faceCount];
+            JValue* indexArgs = stackalloc JValue[1];
+
+            for (int faceIndex = 0; faceIndex < faceCount; faceIndex++)
+            {
+                var landmarkListHandle = GetListItem(outerListHandle, indexArgs, faceIndex);
+                if (landmarkListHandle == IntPtr.Zero)
+                {
+                    faces[faceIndex] = new DetailedFaceLandmarks([], [], [], [], []);
+                    continue;
+                }
+
+                try
+                {
+                    int landmarkCount = JNIEnv.CallIntMethod(landmarkListHandle, RawFaceLandmarkJni.ListSizeMethod);
+                    var xyzCoordinates = new float[landmarkCount * 3];
+                    var visibility = new float[landmarkCount];
+                    var hasVisibility = new bool[landmarkCount];
+                    var presence = new float[landmarkCount];
+                    var hasPresence = new bool[landmarkCount];
+
+                    for (int landmarkIndex = 0; landmarkIndex < landmarkCount; landmarkIndex++)
+                    {
+                        var landmarkHandle = GetListItem(landmarkListHandle, indexArgs, landmarkIndex);
+                        if (landmarkHandle == IntPtr.Zero)
+                            continue;
+
+                        try
+                        {
+                            int coordinateIndex = landmarkIndex * 3;
+                            xyzCoordinates[coordinateIndex] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkXMethod);
+                            xyzCoordinates[coordinateIndex + 1] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkYMethod);
+                            xyzCoordinates[coordinateIndex + 2] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkZMethod);
+
+                            if (TryReadOptionalFloat(landmarkHandle, RawFaceLandmarkJni.LandmarkVisibilityMethod, out float visibilityValue))
+                            {
+                                visibility[landmarkIndex] = visibilityValue;
+                                hasVisibility[landmarkIndex] = true;
+                            }
+
+                            if (TryReadOptionalFloat(landmarkHandle, RawFaceLandmarkJni.LandmarkPresenceMethod, out float presenceValue))
+                            {
+                                presence[landmarkIndex] = presenceValue;
+                                hasPresence[landmarkIndex] = true;
+                            }
+                        }
+                        finally
+                        {
+                            JNIEnv.DeleteLocalRef(landmarkHandle);
+                        }
+                    }
+
+                    faces[faceIndex] = new DetailedFaceLandmarks(xyzCoordinates, visibility, hasVisibility, presence, hasPresence);
+                }
+                finally
+                {
+                    JNIEnv.DeleteLocalRef(landmarkListHandle);
+                }
+            }
+
+            return faces;
+        }
+        finally
+        {
+            JNIEnv.DeleteLocalRef(outerListHandle);
+        }
+    }
+
+    private unsafe float[][] ExtractPackedCoordinates(bool includeZ)
+    {
+        var outerListHandle = JNIEnv.CallObjectMethod(Handle, RawFaceLandmarkJni.FaceLandmarksMethod);
+        if (outerListHandle == IntPtr.Zero)
+            return [];
+
+        try
+        {
+            int faceCount = JNIEnv.CallIntMethod(outerListHandle, RawFaceLandmarkJni.ListSizeMethod);
+            if (faceCount <= 0)
+                return [];
+
+            int coordinateStride = includeZ ? 3 : 2;
+            var faces = new float[faceCount][];
+            JValue* indexArgs = stackalloc JValue[1];
+
+            for (int faceIndex = 0; faceIndex < faceCount; faceIndex++)
+            {
+                var landmarkListHandle = GetListItem(outerListHandle, indexArgs, faceIndex);
+                if (landmarkListHandle == IntPtr.Zero)
+                {
+                    faces[faceIndex] = [];
+                    continue;
+                }
+
+                try
+                {
+                    int landmarkCount = JNIEnv.CallIntMethod(landmarkListHandle, RawFaceLandmarkJni.ListSizeMethod);
+                    var coordinates = new float[landmarkCount * coordinateStride];
+
+                    for (int landmarkIndex = 0; landmarkIndex < landmarkCount; landmarkIndex++)
+                    {
+                        var landmarkHandle = GetListItem(landmarkListHandle, indexArgs, landmarkIndex);
+                        if (landmarkHandle == IntPtr.Zero)
+                            continue;
+
+                        try
+                        {
+                            int coordinateIndex = landmarkIndex * coordinateStride;
+                            coordinates[coordinateIndex] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkXMethod);
+                            coordinates[coordinateIndex + 1] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkYMethod);
+                            if (includeZ)
+                            {
+                                coordinates[coordinateIndex + 2] = JNIEnv.CallFloatMethod(landmarkHandle, RawFaceLandmarkJni.LandmarkZMethod);
+                            }
+                        }
+                        finally
+                        {
+                            JNIEnv.DeleteLocalRef(landmarkHandle);
+                        }
+                    }
+
+                    faces[faceIndex] = coordinates;
+                }
+                finally
+                {
+                    JNIEnv.DeleteLocalRef(landmarkListHandle);
+                }
+            }
+
+            return faces;
+        }
+        finally
+        {
+            JNIEnv.DeleteLocalRef(outerListHandle);
+        }
+    }
+
+    private static unsafe IntPtr GetListItem(IntPtr listHandle, JValue* indexArgs, int index)
+    {
+        indexArgs[0] = new JValue(index);
+        return JNIEnv.CallObjectMethod(listHandle, RawFaceLandmarkJni.ListGetMethod, indexArgs);
+    }
+
+    private static bool TryReadOptionalFloat(IntPtr landmarkHandle, IntPtr optionalMethod, out float value)
+    {
+        value = default;
+
+        var optionalHandle = JNIEnv.CallObjectMethod(landmarkHandle, optionalMethod);
+        if (optionalHandle == IntPtr.Zero)
+            return false;
+
+        try
+        {
+            if (!JNIEnv.CallBooleanMethod(optionalHandle, RawFaceLandmarkJni.OptionalIsPresentMethod))
+                return false;
+
+            var boxedFloatHandle = JNIEnv.CallObjectMethod(optionalHandle, RawFaceLandmarkJni.OptionalGetMethod);
+            if (boxedFloatHandle == IntPtr.Zero)
+                return false;
+
+            try
+            {
+                value = JNIEnv.CallFloatMethod(boxedFloatHandle, RawFaceLandmarkJni.FloatValueMethod);
+                return true;
+            }
+            finally
+            {
+                JNIEnv.DeleteLocalRef(boxedFloatHandle);
+            }
+        }
+        finally
+        {
+            JNIEnv.DeleteLocalRef(optionalHandle);
+        }
+    }
+}


### PR DESCRIPTION
Hi, please let me thank you for this awesome and helpful library.

I've used it on Android and iOS for face landmarks detection with live camera feed (non-stop). 
And Android frame rate was slow, so after investigating possible bottleneck point I found the main lag was coming from mapping landmarks with multiple interops. The `FaceLandmarks`
property returns `IList<IList<NormalizedLandmark>>` — each `NormalizedLandmark`
is a bound Java object, so reading `.X`, `.Y`, `.Z` on 478 landmarks per face
means ~1400 JNI crossings plus a heap of short-lived managed wrapper allocations,
every single frame.

Added (Thanks to Claude Code) new "bulk read" helper methods to `FaceLandmarkerResult` that read same data
directly over JNI into packed `float[]` arrays and skip the wrapper objects entirely:

- `FaceLandmarksXY()` — returns `float[][]`, one array per face, packed `x0, y0, x1, y1, …`
- `FaceLandmarksXYZ()` — same with depth: `x0, y0, z0, x1, y1, z1, …`
- `FaceLandmarksDetailed()` — XYZ plus visibility and presence, for cases where
  we might need the full metadata

The landmark readback time dropped **by more than 10x** compared to traversing the
generated wrapper list.

JNI method IDs are cached once at class init, and a `stackalloc JValue[1]`
scratch buffer is reused for every `list.get(i)` call in the inner loop, so the
hot path only allocates the output arrays themselves. All local JNI refs are
released in `finally` blocks.

**Before (slow):**
```csharp
// ~1400 JNI crossings + wrapper allocations per frame for 478 landmarks
foreach (var face in result.FaceLandmarks)
    foreach (var lm in face)
        DrawPoint(lm.X, lm.Y);
```

**After (fast):**
```csharp
// one JNI call per float, no wrapper objects, output arrays only
float[][] faces = result.FaceLandmarksXY();
foreach (var face in faces)
    for (int i = 0; i < face.Length; i += 2)
        DrawPoint(face[i], face[i + 1]); // coordinates are normalised 0..1
```

Everything new is inside `Additions/FaceLandmarkerResult.cs` file —
nothing existing was touched. The original `FaceLandmarks` property is still
there for cases where you don't need the fast performance, like for still photos etc.

https://github.com/user-attachments/assets/6f1c405d-8bd4-49f8-8a12-49dec6ed7b67

Thanks again!